### PR TITLE
Add Ubuntu support to module.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -3,7 +3,7 @@ class couchdb($download = 'http://mirrors.ircam.fr/pub/apache/couchdb/1.1.1/apac
               $filename = 'apache-couchdb-1.1.1.tar.gz',
               $extension = '.tar.gz',
               $foldername = 'apache-couchdb-1.1.1',
-              $buildoptions = '',
+              $buildopts = '',
               $rm_build_folder = false,
               $bind = '127.0.0.1',
               $database_dir = '/usr/local/var/lib/couchdb',
@@ -14,6 +14,33 @@ class couchdb($download = 'http://mirrors.ircam.fr/pub/apache/couchdb/1.1.1/apac
               $uuids = 'utc_random',
               $cert_path = '/usr/local/etc/certs',
               $ulimit = '65536') {
+
+    case $operatingsystem {
+      'Ubuntu': {
+        case $operatingsystemrelease {
+          '10.04': {
+            $packages = ['build-essential',
+                         'xulrunner-1.9.2-dev',
+                         'libicu-dev',
+                         'libcurl4-gnutls-dev',
+                         'libtool',
+                         'erlang',
+                         'erlang-eunit']
+            $buildoptions = '--with-js-include=/usr/lib/xulrunner-devel-1.9.2.28/include --with-js-lib=/usr/lib/xulrunner-devel-1.9.2.28/lib'
+          }
+          default: {}
+        }
+      }
+      default: {
+        $packages = ['build-essential',
+                              'erlang',
+                              'libicu-dev',
+                              'libmozjs-dev',
+                              'libcurl4-openssl-dev',
+                              'curl']
+        $buildoptions = $buildopts
+      }
+    }
 
     include couchdb::install,
             couchdb::service,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -5,8 +5,7 @@ class couchdb::install {
     }
 
     package {
-        ['build-essential', 'erlang', 'libicu-dev',
-        'libmozjs-dev', 'libcurl4-openssl-dev', 'curl']:
+      $couchdb::packages :
         ensure => 'installed',
     }
 
@@ -51,10 +50,7 @@ class couchdb::install {
         timeout => '600',
         require => [
             Exec['extract'],
-            Package[
-                'build-essential', 'erlang', 'libicu-dev',
-                'libmozjs-dev', 'libcurl4-openssl-dev', 'curl'
-            ]
+            Package[$couchdb::packages]
         ],
     }
 


### PR DESCRIPTION
- Add case statement to set packages and buildoptions based on OS and OS Release.
- Change buildoptions class attribute to avoid conflict with buildoptions set in the case statement.

Needs tested with Debian Squeeze. I tried but couldn't get standalone puppet working properly on a debian vm. I would gladly test it for you if you have a virtualbox vm or vagrant basebox that I could test it on.
