### PR TITLE
Wrap package declaration with if defined

### DIFF
--- a/manifests/ssl.pp
+++ b/manifests/ssl.pp
@@ -1,7 +1,9 @@
 class couchdb::ssl {
 
-  package { ['openssl']:
-    ensure => installed,
+  if ! defined(Package['openssl']) {
+    package { ['openssl']:
+      ensure => installed,
+    }
   }
 
   file { $couchdb::cert_path:


### PR DESCRIPTION
We already had an openssl package defined, and it was pinned to a specific version, so I needed to update this.  Per https://projects.puppetlabs.com/issues/18490 this is an antipattern, but the only workaround I'm aware of.