### PR TITLE
fix package name so Ubuntu 14.04 finds it

### DIFF
--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -34,6 +34,19 @@ class couchdb::package {
             notify  => Service['couchdb'],
           }
         }
+        '14.04': {
+          $dependencies = [
+            'erlang-base',
+            'erlang-dev',
+            'erlang-eunit',
+            'erlang-nox', 
+            'libicu-dev',
+            'libmozjs185-dev',
+            'libcurl4-gnutls-dev',
+            'libtool',
+          ] 
+          $buildoptions = $couchdb::buildopts
+        }
         default: {
           $dependencies = [
             'erlang-base',


### PR DESCRIPTION
Ubuntu 14.04 complains about "libmozjs-dev":
E: Unable to locate package libmozjs-dev

Specifying the package version to libmozjs185-dev satisfies apt. 